### PR TITLE
Fix Windows error on chained db migrate scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,12 @@
     "db-migrate": "db-migrate up",
     "db-rollback": "db-migrate down",
     "db-reset": "db-migrate reset",
-    "db-refresh": "db-migrate reset; db-migrate reset:seed; db-migrate up; db-migrate up:seed;",
-    "dev-db-refresh": "db-migrate reset; db-migrate reset:seed; db-migrate reset:seed-test-data; db-migrate up; db-migrate up:seed; db-migrate up:seed-test-data;"
+    "db-refresh": "run-script-os",
+    "db-refresh:default": "db-migrate reset; db-migrate reset:seed; db-migrate up; db-migrate up:seed;",
+    "db-refresh:win32": "db-migrate reset & db-migrate reset:seed & db-migrate up & db-migrate up:seed",
+    "dev-db-refresh": "run-script-os",
+    "dev-db-refresh:default": "db-migrate reset; db-migrate reset:seed; db-migrate reset:seed-test-data; db-migrate up; db-migrate up:seed; db-migrate up:seed-test-data;",
+    "dev-db-refresh:win32": "db-migrate reset & db-migrate reset:seed & db-migrate reset:seed-test-data & db-migrate up & db-migrate up:seed & db-migrate up:seed-test-data"
   },
   "author": "",
   "license": "ISC",
@@ -27,7 +31,8 @@
     "jsonwebtoken": "^8.5.1",
     "jwk-to-pem": "^2.0.1",
     "morgan": "^1.9.1",
-    "pg": "^7.11.0"
+    "pg": "^7.11.0",
+    "run-script-os": "^1.0.7"
   },
   "devDependencies": {
     "eslint": "^6.1.0",


### PR DESCRIPTION
This fixes an error on Windows when following the Getting Started README instructions and running 'npm dev-db-refresh' to execute the database migrations.

Semicolons in package.json scripts with multiple commands aren't compatible with Windows, e.g. "db-migrate reset; db-migrate reset:seed;... ", instead Windows separates commands with an ampersand "db-migrate reset & db-migrate reset:seed & ... "

npm seems to spawn Windows command shell cmd.exe to run scripts, even if executing scripts from a bash emulator.

[run-script-os](https://www.npmjs.com/package/run-script-os) npm package allows OS-specific scripts in package.json. Seems to be a [known problem](https://github.com/npm/npm/issues/4040) and I didn't find any other clean or recent solutions.

I tested a fresh install from this branch on my Windows 10 Home machine, inspected the db migrations via SQL client and confirmed the seeded data displays in the neighborhood-connect app.